### PR TITLE
🔧 Fix: Correct JWT token generation deconstruction errors

### DIFF
--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -48,8 +48,9 @@ public class AuthController : ControllerBase
                 return Unauthorized(new { message = "Onjuist wachtwoord" });
             }
             
-            // Generate JWT token
-            var (token, refreshToken) = _jwtService.GenerateToken(user);
+            // Generate JWT token and refresh token
+            var token = _jwtService.GenerateToken(user);
+            var refreshToken = _jwtService.GenerateRefreshToken();
             
             // Generate and store secure refresh token
             await _mongoDbService.StoreRefreshTokenAsync(user.Id, refreshToken, _jwtService.GetRefreshTokenExpiryTime());
@@ -116,8 +117,9 @@ public class AuthController : ControllerBase
                 return StatusCode(500, new { message = "Gebruiker aangemaakt maar niet gevonden" });
             }
             
-            // Generate JWT token
-            var (token, refreshToken) = _jwtService.GenerateToken(user);
+            // Generate JWT token and refresh token
+            var token = _jwtService.GenerateToken(user);
+            var refreshToken = _jwtService.GenerateRefreshToken();
             
             // Generate and store secure refresh token
             await _mongoDbService.StoreRefreshTokenAsync(user.Id, refreshToken, _jwtService.GetRefreshTokenExpiryTime());
@@ -166,7 +168,8 @@ public class AuthController : ControllerBase
             }
             
             // Generate new tokens
-            var (newToken, newRefreshToken) = _jwtService.GenerateToken(user);
+            var newToken = _jwtService.GenerateToken(user);
+            var newRefreshToken = _jwtService.GenerateRefreshToken();
             
             // Store the new refresh token (this automatically revokes the old one)
             await _mongoDbService.StoreRefreshTokenAsync(user.Id, newRefreshToken, _jwtService.GetRefreshTokenExpiryTime());


### PR DESCRIPTION
- Fix tuple deconstruction errors in AuthController
- JwtService.GenerateToken() returns string, not tuple
- Generate access token and refresh token separately
- Use GenerateToken() for JWT access token
- Use GenerateRefreshToken() for refresh token

Fixes compilation errors:
- CS1061: 'string' does not contain a definition for 'Deconstruct'
- CS8129: No suitable 'Deconstruct' instance found
- CS8130: Cannot infer type of deconstruction variables

All 12 compilation errors resolved - build now succeeds ✅