### PR TITLE
chore: Update MongoDB.Driver version and simplify Hangfire connection…

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -23,25 +23,9 @@ builder.Services.AddScoped<ReminderBackgroundService>();
 
 // Configure Hangfire with MongoDB
 var baseConnectionString = builder.Configuration.GetConnectionString("MongoDB") ?? "mongodb://localhost:27017";
-var hangfireConnectionString = baseConnectionString;
 
-// Add database name if not present
-if (!baseConnectionString.Contains("/GhareebDB"))
-{
-    if (baseConnectionString.Contains("?"))
-    {
-        // Insert database name before query parameters
-        hangfireConnectionString = baseConnectionString.Replace("/?", "/GhareebDB?");
-        if (!hangfireConnectionString.Contains("/GhareebDB"))
-        {
-            hangfireConnectionString = baseConnectionString.Replace("?", "/GhareebDB?");
-        }
-    }
-    else
-    {
-        hangfireConnectionString = $"{baseConnectionString.TrimEnd('/')}/GhareebDB";
-    }
-}
+// For Hangfire, use a explicit database name format
+var hangfireConnectionString = "mongodb+srv://salimazazouaoui:U6jYsyqbnqQpcY9Z@cluster0.lswrffy.mongodb.net/GhareebDB?retryWrites=true&w=majority&appName=Cluster0";
 
 var migrationOptions = new MongoMigrationOptions
 {

--- a/server.csproj
+++ b/server.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.15" />
-    <PackageReference Include="MongoDB.Driver" Version="3.3.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.29.0" />
 	  <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     
     <!-- Background Jobs -->


### PR DESCRIPTION
… string

- Downgraded MongoDB.Driver package from version 3.3.0 to 2.29.0 for compatibility.
- Simplified Hangfire connection string in Program.cs to use a direct connection format with the database name included.